### PR TITLE
Add am/pm prioritization hours, when not specified.

### DIFF
--- a/lib/bot/timezones.js
+++ b/lib/bot/timezones.js
@@ -54,7 +54,12 @@ module.exports = message => {
     let hours = parseInt(match[4] || match[7] || match[9] || 0, 10)
     const minutes = parseInt(match[5] || 0, 10)
 
-    const amOrPm = match[6] || match[8]
+    let amOrPm = match[6] || match[8]
+    // if am or pm isn't specified, make an inference about the most likely time.
+    // this prioritizes 9am to 8:59pm
+    if (!amOrPm && hours < 9) {
+      amOrPm = 'pm'
+    }
     if (amOrPm && amOrPm.toLowerCase() === 'pm') {
       hours += 12
     }


### PR DESCRIPTION
Pretty straightforward PR, just a quality of life update.

Currently, when am/pm isn't specified, an assumption is made that AM is being referenced. This often does not represent reality.

The human ability to divine AM or PM based on context would be nice, but failing that, let's prioritize 9am-8:59pm in the speaker's home time zone.